### PR TITLE
Fix pod metadata overwritten caused by updateStatus

### DIFF
--- a/internal/podutils/pod_status.go
+++ b/internal/podutils/pod_status.go
@@ -1,0 +1,104 @@
+// Copyright © 2021 The virtual-kubelet authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package podutils
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/strategicpatch"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+)
+
+// PodConditionsByProvider is the list of pod conditions owned by provider
+var PodConditionsByProvider = []corev1.PodConditionType{
+	corev1.PodScheduled,
+	corev1.PodReady,
+	corev1.PodInitialized,
+	corev1.PodReasonUnschedulable,
+	corev1.ContainersReady,
+}
+
+// podConditionByProvider returns if the pod condition type is owned by provider
+func podConditionByProvider(conditionType corev1.PodConditionType) bool {
+	for _, c := range PodConditionsByProvider {
+		if c == conditionType {
+			return true
+		}
+	}
+	return false
+}
+
+// PatchPodStatus patches pod status.
+func PatchPodStatus(c corev1client.PodsGetter,
+	namespace, name string, oldPodStatus, newPodStatus corev1.PodStatus) (*corev1.Pod, []byte, error) {
+	patchBytes, err := preparePatchBytesForPodStatus(namespace, name, oldPodStatus,
+		mergePodStatus(oldPodStatus, newPodStatus))
+	if err != nil {
+		return nil, nil, err
+	}
+
+	updatedPod, err := c.Pods(namespace).Patch(context.TODO(),
+		name, types.StrategicMergePatchType, patchBytes, metav1.PatchOptions{}, "status")
+	if err != nil {
+		return nil, nil, err
+	}
+	return updatedPod, patchBytes, nil
+}
+
+func preparePatchBytesForPodStatus(namespace, name string, oldPodStatus, newPodStatus corev1.PodStatus) ([]byte, error) {
+	oldData, err := json.Marshal(corev1.Pod{
+		Status: oldPodStatus,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to Marshal oldData for pod %q/%q: %v", namespace, name, err)
+	}
+
+	newData, err := json.Marshal(corev1.Pod{
+		Status: newPodStatus,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to Marshal newData for pod %q/%q: %v", namespace, name, err)
+	}
+
+	patchBytes, err := strategicpatch.CreateTwoWayMergePatch(oldData, newData, corev1.Pod{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to CreateTwoWayMergePatch for pod %q/%q: %v", namespace, name, err)
+	}
+	return patchBytes, nil
+}
+
+// mergePodStatus merges oldPodStatus and newPodStatus where pod conditions
+// not owned by provider is preserved from oldPodStatus
+func mergePodStatus(oldPodStatus, newPodStatus corev1.PodStatus) corev1.PodStatus {
+	var podConditions []corev1.PodCondition
+	for _, c := range oldPodStatus.Conditions {
+		if !podConditionByProvider(c.Type) {
+			podConditions = append(podConditions, c)
+		}
+	}
+
+	for _, c := range newPodStatus.Conditions {
+		if podConditionByProvider(c.Type) {
+			podConditions = append(podConditions, c)
+		}
+	}
+	newPodStatus.Conditions = podConditions
+	return newPodStatus
+}

--- a/internal/podutils/pod_status_test.go
+++ b/internal/podutils/pod_status_test.go
@@ -1,0 +1,115 @@
+// Copyright © 2021 The virtual-kubelet authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package podutils
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestPatchPodStatus(t *testing.T) {
+	ns := "ns"
+	name := "name"
+	client := (&fake.Clientset{}).CoreV1()
+	client.Pods(ns).Create(context.TODO(), &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: ns,
+			Name:      name,
+		},
+	}, metav1.CreateOptions{})
+
+	testCases := []struct {
+		description        string
+		mutate             func(input v1.PodStatus) v1.PodStatus
+		expectedPatchBytes []byte
+	}{
+		{
+			"no change",
+			func(input v1.PodStatus) v1.PodStatus { return input },
+			[]byte(fmt.Sprintf(`{}`)),
+		},
+		{
+			"message change",
+			func(input v1.PodStatus) v1.PodStatus {
+				input.Message = "random message"
+				return input
+			},
+			[]byte(fmt.Sprintf(`{"status":{"message":"random message"}}`)),
+		},
+		{
+			"pod condition change",
+			func(input v1.PodStatus) v1.PodStatus {
+				input.Conditions[0].Status = v1.ConditionFalse
+				return input
+			},
+			[]byte(fmt.Sprintf(`{"status":{"$setElementOrder/conditions":[{"type":"Ready"},{"type":"PodScheduled"}],"conditions":[{"status":"False","type":"Ready"}]}}`)),
+		},
+		{
+			"additional init container condition",
+			func(input v1.PodStatus) v1.PodStatus {
+				input.InitContainerStatuses = []v1.ContainerStatus{
+					{
+						Name:  "init-container",
+						Ready: true,
+					},
+				}
+				return input
+			},
+			[]byte(fmt.Sprintf(`{"status":{"initContainerStatuses":[{"image":"","imageID":"","lastState":{},"name":"init-container","ready":true,"restartCount":0,"state":{}}]}}`)),
+		},
+	}
+	for _, tc := range testCases {
+		_, patchBytes, err := PatchPodStatus(client, ns, name, getPodStatus(), tc.mutate(getPodStatus()))
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if !reflect.DeepEqual(patchBytes, tc.expectedPatchBytes) {
+			t.Errorf("for test case %q, expect patchBytes: %q, got: %q\n", tc.description, tc.expectedPatchBytes, patchBytes)
+		}
+	}
+}
+
+func getPodStatus() v1.PodStatus {
+	return v1.PodStatus{
+		Phase: v1.PodRunning,
+		Conditions: []v1.PodCondition{
+			{
+				Type:   v1.PodReady,
+				Status: v1.ConditionTrue,
+			},
+			{
+				Type:   v1.PodScheduled,
+				Status: v1.ConditionTrue,
+			},
+		},
+		ContainerStatuses: []v1.ContainerStatus{
+			{
+				Name:  "container1",
+				Ready: true,
+			},
+			{
+				Name:  "container2",
+				Ready: true,
+			},
+		},
+		Message: "Message",
+	}
+}

--- a/node/pod.go
+++ b/node/pod.go
@@ -20,11 +20,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/virtual-kubelet/virtual-kubelet/internal/queue"
-
 	"github.com/google/go-cmp/cmp"
 	pkgerrors "github.com/pkg/errors"
 	"github.com/virtual-kubelet/virtual-kubelet/internal/podutils"
+	"github.com/virtual-kubelet/virtual-kubelet/internal/queue"
 	"github.com/virtual-kubelet/virtual-kubelet/log"
 	"github.com/virtual-kubelet/virtual-kubelet/trace"
 	"go.opentelemetry.io/otel/attribute"
@@ -199,7 +198,7 @@ func (pc *PodController) handleProviderError(ctx context.Context, span trace.Spa
 		podPhase = corev1.PodFailed
 	}
 
-	pod.ResourceVersion = "" // Blank out resource version to prevent object has been modified error
+	oldStatus := pod.Status.DeepCopy()
 	pod.Status.Phase = podPhase
 	pod.Status.Reason = podStatusReasonProviderFailed
 	pod.Status.Message = origErr.Error()
@@ -209,7 +208,7 @@ func (pc *PodController) handleProviderError(ctx context.Context, span trace.Spa
 		"reason":   pod.Status.Reason,
 	})
 
-	_, err := pc.client.Pods(pod.Namespace).UpdateStatus(ctx, pod, metav1.UpdateOptions{})
+	_, _, err := podutils.PatchPodStatus(pc.client, pod.Namespace, pod.Name, *oldStatus, pod.Status)
 	if err != nil {
 		logger.WithError(err).Warn("Failed to update pod status")
 	} else {
@@ -277,12 +276,9 @@ func (pc *PodController) updatePodStatus(ctx context.Context, podFromKubernetes 
 			}
 		}
 	}
-
-	// We need to do this because the other parts of the pod can be updated elsewhere. Since we're only updating
-	// the pod status, and we should be the sole writers of the pod status, we can blind overwrite it. Therefore
-	// we need to copy the pod and set ResourceVersion to 0.
-	podFromProvider.ResourceVersion = "0"
-	if _, err := pc.client.Pods(podFromKubernetes.Namespace).UpdateStatus(ctx, podFromProvider, metav1.UpdateOptions{}); err != nil && !errors.IsNotFound(err) {
+	oldStatus := podFromKubernetes.Status.DeepCopy()
+	newStatus := podFromProvider.Status.DeepCopy()
+	if _, _, err := podutils.PatchPodStatus(pc.client, podFromKubernetes.Namespace, podFromKubernetes.Name, *oldStatus, *newStatus); err != nil && !errors.IsNotFound(err) {
 		span.SetStatus(err)
 		return pkgerrors.Wrap(err, "error while updating pod status in kubernetes")
 	}


### PR DESCRIPTION
This PR pulls an old not committed fix from the upstream (https://github.com/virtual-kubelet/virtual-kubelet/pull/976)

The fix makes sure that when pod labels are modified (`kubectl label`, for example), the newly assigned labels won't be overwritten. 